### PR TITLE
Fix Content-Length header

### DIFF
--- a/src/FormData.js
+++ b/src/FormData.js
@@ -38,7 +38,7 @@ class FormData {
   }
 
   get length() {
-    return this.buffers.reduce((sum, b) => Buffer.byteLength(b), 0);
+    return this.buffers.reduce((sum, b) => sum + Buffer.byteLength(b), 0);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -224,9 +224,9 @@ class Snekfetch extends Stream.Readable {
         });
       });
 
+      const data = this.data ? this.data.end ? this.data.end() : this.data : null;
       this._addFinalHeaders();
       if (this.request.query) this.request.path = `${this.request.path}?${qs.stringify(this.request.query)}`;
-      const data = this.data ? this.data.end ? this.data.end() : this.data : null;
       if (Array.isArray(data)) {
         for (const chunk of data) request.write(chunk);
         request.end();


### PR DESCRIPTION
~~if your pr is about typescript go away~~ Don't worry, it's not.

This appends the termating boundary before the `Content-Length` header will be set,
and correctly adds up the length of the buffers, when doing so.