### PR TITLE
status is now statusCode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -209,7 +209,7 @@ class Snekfetch extends transport.Parent {
   end(cb) {
     return this.then(
       (res) => (cb ? cb(null, res) : res),
-      (err) => (cb ? cb(err, err.status ? err : null) : Promise.reject(err)),
+      (err) => (cb ? cb(err, err.statusCode ? err : null) : Promise.reject(err)),
     );
   }
 

--- a/test/main.js
+++ b/test/main.js
@@ -166,3 +166,10 @@ test('redirects', () =>
       expect(res.body).not.toBeUndefined();
       expect(res.body.url).toBe(`${TestRoot}/get`);
     }));
+
+test('res should be defined when rejecting', () =>
+  Snekfetch.get(`${TestRoot}/404`)
+    .end((err, res) => {
+      expect(err.statusCode).not.toBeUndefined();
+      expect(res).not.toBe(null);
+    }));


### PR DESCRIPTION
~~if your pr is about typescript go away~~ ur a ts

You changed err.status to err.statusCode, but probably forgot for this check. This means res will always be null.
