### PR TITLE
fix: Certain files getting corrupted when gotten

### DIFF
--- a/src/node/index.js
+++ b/src/node/index.js
@@ -67,7 +67,7 @@ function request(snek, options = snek.options) {
 
     req.on('error', reject);
 
-    let body = '';
+    let body = [];
     let headers;
     let statusCode;
     let statusText;
@@ -97,14 +97,14 @@ function request(snek, options = snek.options) {
         if (!snek.push(chunk)) {
           snek.pause();
         }
-        body += chunk;
+        body.push(chunk);
       });
 
       stream.once('error', reject);
 
       stream.once('end', () => {
         snek.push(null);
-        const raw = Buffer.from(body);
+        const raw = Buffer.concat(body);
         if (options.connection && options.connection.close) {
           options.connection.close();
         }

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -67,7 +67,7 @@ function request(snek, options = snek.options) {
 
     req.on('error', reject);
 
-    let body = [];
+    const body = [];
     let headers;
     let statusCode;
     let statusText;


### PR DESCRIPTION
This PR fixes the issue where data would get corrupt when downloading (try downloading a png file with this PR and without, you'll see which one yields the right one)

Fixes #42 


