### PR TITLE
improve reliability of the browser/node check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const transport = require(typeof window !== 'undefined' ? './browser' : './node');
+const transport = require(typeof process === 'undefined' ? './browser' : './node');
 
 /**
  * Snekfetch


### PR DESCRIPTION
this fixes compatibility with a popular GTAV modification framework, FiveM. they define the window object as an alias for global, so the check was always returning "./browser", causing errors to appear when snekfetch tried using the window.fetch method.
